### PR TITLE
Fixed 'embed' option, it will now work when set to 'true' 

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function (content) {
       classPrefix: 'classPrefix' in config ? config.classPrefix : 'icon-'
     },
     dest: '',
-    writeFiles: false,
+    writeFiles: config.embed || false,
     formatOptions: config.formatOptions || {}
   };
 
@@ -151,7 +151,8 @@ module.exports = function (content) {
   var pub = (
     generatorConfiguration.dest || (opts.output && opts.output.publicPath) || '/'
   );
-  var embed = !!params.embed;
+
+  var embed = !!generatorConfiguration.writeFiles;
 
   if (generatorConfiguration.cssTemplate) {
     this.addDependency(generatorConfiguration.cssTemplate);
@@ -168,6 +169,7 @@ module.exports = function (content) {
     var urls = {};
     for (var i in formats) {
       var format = formats[i];
+
       if (!embed) {
         var filename = config.fileName || params.fileName || '[chunkhash]-[fontname].[ext]';
         var chunkHash = filename.indexOf('[chunkhash]') !== -1 ? hashFiles(generatorConfiguration.files, params.hashLength) : '';

--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ module.exports = function (content) {
   var pub = (
     generatorConfiguration.dest || (opts.output && opts.output.publicPath) || '/'
   );
-
   var embed = !!generatorConfiguration.embed;
 
   if (generatorConfiguration.cssTemplate) {
@@ -168,13 +167,11 @@ module.exports = function (content) {
       return cb(err);
     }
     var urls = {};
-
     for (var i in formats) {
-      var format = formats[i],
-          filename = config.fileName || params.fileName || '[chunkhash]-[fontname].[ext]',
-
-          chunkHash = filename.indexOf('[chunkhash]') !== -1 ?
-            hashFiles(generatorConfiguration.files, params.hashLength) : '';
+      var format = formats[i];
+      var filename = config.fileName || params.fileName || '[chunkhash]-[fontname].[ext]';
+      var chunkHash = filename.indexOf('[chunkhash]') !== -1
+            ? hashFiles(generatorConfiguration.files, params.hashLength) : '';
 
       filename = filename
                   .replace('[chunkhash]', chunkHash)
@@ -196,23 +193,18 @@ module.exports = function (content) {
       }
 
       if (!embed) {
-
         if (isUrl(pub)) {
           urls[format] = url.resolve(pub, formatUrl);
         } else {
           urls[format] = path.join(pub, formatUrl);
         }
         urls[format] = urls[format].replace(/\\/g, '/');
-
       } else {
-
         urls[format] = 'data:' +
         mimeTypes[format] +
         ';charset=utf-8;base64,' +
         (Buffer.from(res[format]).toString('base64'));
-
       }
-
     }
 
     cb(null, res.generateCss(urls));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfonts-loader",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "A WebPack loader to automaticaly generate font files and CSS to make your own icon font",
   "repository": "jeerbl/webfonts-loader",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webfonts-loader",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A WebPack loader to automaticaly generate font files and CSS to make your own icon font",
   "repository": "jeerbl/webfonts-loader",
   "main": "index.js",

--- a/test/myfont.font.js
+++ b/test/myfont.font.js
@@ -7,5 +7,6 @@ module.exports = {
   'baseSelector': '.myfonticon',
   'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
   'fixedWidth': true,
+  'embed': true,
   'fileName': 'app.[fontname].[chunkhash].[ext]'
 };


### PR DESCRIPTION
- Wired up 'embed' boolean option to 'writeFiles' ...generatorConfig will now use the value from the config using key 'embed' with a boolean of true or false - this is already documented in the readme but it did not work

- test example config should embed font files …for best practise and performance, base64 encode files in the example - really this could be default

Please can you merge and push new version into NPM for v2.0.4 to resolve this issue :)

