### PR TITLE
Fix handling of dest and publicPath options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # webfonts-loader
+
 [![npm](https://img.shields.io/npm/v/webfonts-loader.svg?style=flat-square)](https://www.npmjs.com/package/webfonts-loader)
 [![Travis](https://img.shields.io/travis/jeerbl/webfonts-loader.svg?style=flat-square)](https://travis-ci.org/jeerbl/webfonts-loader)
 [![license](https://img.shields.io/github/license/jeerbl/webfonts-loader.svg?style=flat-square)](https://github.com/jeerbl/webfonts-loader/blob/master/LICENSE)
@@ -8,15 +9,19 @@ A loader that generates fonts from your SVG icons and allows you to use your ico
 `webfonts-loader` uses the [`webfonts-generator`](https://github.com/sunflowerdeath/webfonts-generator) plugin to create fonts in any format. It also generates CSS files so that you can use your icons directly in your HTML, using CSS classes.
 
 ## Installation
+
 ```
 npm install webfonts-loader
 ```
 
 ## Usage
+
 An example of usage can be found in the `test/` directory of this repository.
 
 ### Webpack rule
+
 Add this rule to your Webpack config:
+
 ```javascript
 {
   test: /\.font\.js/,
@@ -29,13 +34,45 @@ Add this rule to your Webpack config:
   })
 }
 ```
+
 So that each font configuration file will be loaded using this rule.
+
+#### Loader options
+
+You can provide `options` objects to configure the loader behaviour:
+
+```javascript
+{
+  test: /\.font\.js/,
+  loader: ExtractTextPlugin.extract({
+    use: [
+      'style-loader',
+      'css-loader',
+      {
+        loader: 'webfonts-loader',
+        options: { ... }
+      }
+    ]
+  })
+}
+```
+
+Available options are:
+
+##### `publicPath`, String
+
+This is the URL prefix for generated links (e.g. `/static/` or `https://cdn.project.net/`). Should typically match Webpack's `config.output.publicPath`.
+
+##### Any font config option
+
+If you pass `types`, `fileName` or any other font config option, it will be used as a default (unless overriden in font config file).
 
 ### The font configuration file
 
 #### Description
 
 The config file allows you to specify parameters for the loader to use. Here is an example configuration file:
+
 ```javascript
 // myfont.font.js
 module.exports = {
@@ -51,56 +88,72 @@ module.exports = {
 ```
 
 Then you have to require the configuration file:
+
 ```javascript
 // entry.js
 require('./myfont.font');
 ```
 
 The loader will then generate:
+
 * CSS with the base and class prefix
 * Font files for the SVG icons
 
 #### All font configuration options
 
 ##### `baseSelector`, String
+
 The base CSS selector, under which each icon class is to be created.
 See [webfonts-generator#templateoptions](https://github.com/sunflowerdeath/webfonts-generator#templateoptions)
 
 ##### `classPrefix`, String
+
 The prefix to be used with each icon class.
 See [webfonts-generator#templateoptions](https://github.com/sunflowerdeath/webfonts-generator#templateoptions)
 
 ##### `cssTemplate`, String
+
 See [webfonts-generator#csstemplate](https://github.com/sunflowerdeath/webfonts-generator#csstemplate)
 
 ##### `embed`, Boolean
+
 If true the font is encoded in base64 and embedded inside the `@font-face` declaration, otherwise font files are written to disk.
 Default: `false`
 
 ##### `hashLength`, Number
+
 Optional. The length of hash in `fileName`.
 Min: 8
 Max: 32
 Default: 20
 
 ##### `fileName`, String
+
 The generated font file names. These elements can be used:
+
 * `[fontname]`: the value of the `fontName` parameter
 * `[ext]`: the extension of the font file being generated (`eot`, ...)
 * `[hash]`: the hash of the current compilation
 * `[chunkhash]`: the hash of the SVG files
 
+This option can be also configured globally in the webpack loader options.
+
 ##### `files`, Array
+
 See [webfonts-generator#files](https://github.com/sunflowerdeath/webfonts-generator#files)
 
 ##### `fontName`, String
+
 See [webfonts-generator#fontname](https://github.com/sunflowerdeath/webfonts-generator#fontname)
 
 ##### `formatOptions`, Object
+
 See [webfonts-generator#formatoptions](https://github.com/sunflowerdeath/webfonts-generator#formatoptions)
 
 ##### `rename`, Function
+
 See [webfonts-generator#rename](https://github.com/sunflowerdeath/webfonts-generator#rename)
 
 ##### `types`, Array<String>
+
 See [webfonts-generator#types](https://github.com/sunflowerdeath/webfonts-generator#types)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var loaderUtils = require('loader-utils');
 var webfontsGenerator = require('webfonts-generator');
 var path = require('path');
 var glob = require('glob');
-var isUrl = require('is-url');
 var url = require('url');
 var hashFiles = require('./utils').hashFiles;
 
@@ -65,15 +64,15 @@ function wpGetOptions (context) {
 module.exports = function (content) {
   this.cacheable();
 
-  var webpackOptions = this.options || {};
-  var options = wpGetOptions(this);
+  var webpackOptions = this.options || {}; // only makes sense in Webpack 1.x, or when LoaderOptionsPlugin is used
+  var options = wpGetOptions(this) || {};
   var rawFontConfig;
   try {
     rawFontConfig = JSON.parse(content);
   } catch (ex) {
     rawFontConfig = this.exec(content, this.resourcePath);
   }
-  var fontConfig = Object.assign({}, options, rawFontConfig)
+  var fontConfig = Object.assign({}, options, rawFontConfig);
 
   var filesAndDeps = getFilesAndDeps(fontConfig.files, this.context);
   filesAndDeps.dependencies.files.forEach(this.addDependency.bind(this));

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "glob": "^7.1.1",
     "hash-files": "^1.1.1",
-    "is-url": "^1.2.2",
     "loader-utils": "^1.0.2",
     "webfonts-generator": "^0.4.0"
   },


### PR DESCRIPTION
This PR fixes handling of `dest` and `publicPath` opts (#36):

* `dest` is no more used directly. It's simply passed to webfonts generator if provided.
* `publicPath` is used to construct font URLs, and supports fully-qualified URL prefix like `http://cdn.project.net/`
* all other loader options are used as defaults for font configs

Loading and merging of options is streamlined, and the variables are renamed uniformly:

* `params` is now `options`, as in "Webpack loader options" (I also removed duplicate call to `loaderUtils.getOptions()`)
* `opts` is now `webpackOptions`, as it refers to global webpack config options (in webpack 1.x, or when `LoaderOptionsPlugin` is used)
* `config` is now `fontConfig`, as in "font config"
* `generatorConfiguration` is now `generatorOptions`, as in `webfontsGenerator(options, ...)`
* `pub` is now `publicPath`, same as in Webpack