### PR TITLE
Removed 'style-loader' as per this issue - https://github.com/webpack…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Add this rule to your Webpack config:
   test: /\.font\.js/,
   loader: ExtractTextPlugin.extract({
     use: [
-      'style-loader',
       'css-loader',
       'webfonts-loader'
     ]


### PR DESCRIPTION
I was getting the error described in the referenced issue till I removed 'style-loader'.  Suggestion to update the docs to follow suit with that issue and the resolution.

#https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/503