### PR TITLE
New option: emitCodepoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,46 @@ The generated font file names. These elements can be used:
 
 This option can be also configured globally in the webpack loader options.
 
+##### `emitCodepoints`, Array (with shorthand versions of Boolean, String and Object)
+
+Optional. The generated codepoints file names. 
+
+Examples:
+
+* `emitCodepoints: true`: emits a javascript file named `[fontname].codepoints.js` in the `web` (default) format
+* `emitCodepoints: '[fontname].codepoints.fonts.js'`: emits a javascript file named `[fontname].codepoints.fonts.js` in the `commonjs` format
+* `emitCodepoints: { fileName: '[fontname].codepoints.json', type: 'json'] }`: emits a file named `[fontname].codepoints.json` in the `json` format
+* `emitCodepoints: [{ fileName: '[fontname].codepoints.json', type: 'json'] }, { fileName: '[fontname].codepoints.js', type: 'web'] }, { fileName: '[fontname].codepoints.inc.js', type: 'web'] }]`: emits three files with their respective names and types
+
+These are the existing formats:
+
+* `web`: (default): generates a file containing the array of codepoints in a format suitable for inclusion in html pages.
+
+Example (for a font named myfonticons): 
+```javascript
+if (typeof webfontIconCodepoints === 'undefined') {
+  webfontIconCodepoints = {};
+}
+webfontIconCodepoints["myfonticons"] = {"alert":61697,"arrow-down":61698,"arrow-left":61699};
+```
+
+* `commonjs`: generates a file containing the array of codepoints in the commonjs format, for use with `require`.
+```javascript
+module.exports = {"alert":61697,"arrow-down":61698,"arrow-left":61699}
+```
+
+* `json`: generates a file containing the array of codepoints in the JSON format.
+```javascript
+{"alert":61697,"arrow-down":61698,"arrow-left":61699,"arrow-right":61700,"arrow-small-down":61701}
+```
+
+These elements can be used in the filename:
+
+* `[fontname]`: the value of the `fontName` parameter
+* `[chunkhash]`: the hash of the SVG files
+
+This option can be also configured globally in the webpack loader options.
+
 ##### `files`, Array
 
 See [webfonts-generator#files](https://github.com/sunflowerdeath/webfonts-generator#files)

--- a/emit-codepoints.js
+++ b/emit-codepoints.js
@@ -1,0 +1,57 @@
+var loaderUtils = require('loader-utils');
+module.exports = {
+  createArrayCodepointFiles(codepointFiles, elem) {
+    const default_elem = { fileName: '[fontname].codepoints.js', type: 'web' };
+    if (typeof(elem) === 'boolean') {
+      codepointFiles.push(Object.assign({}, default_elem));
+    }
+		else if (typeof(elem) === 'string') {
+      codepointFiles.push(Object.assign({}, default_elem, { fileName: elem }));
+    }
+    else if (Array.isArray(elem)) {
+      elem.forEach(e => this.createArrayCodepointFiles(codepointFiles, e));
+    }
+    else if (typeof(elem) === 'object') {
+      codepointFiles.push(Object.assign({}, default_elem, elem));
+    }
+  },
+  emitFiles(loaderContext, emitCodepointsOptions, generatorOptions) {
+    var codepointFiles = [];
+    this.createArrayCodepointFiles(codepointFiles, emitCodepointsOptions);
+    codepointFiles.forEach(emitOption => {
+      var codepointsContent = JSON.stringify(generatorOptions.codepoints);
+      switch (emitOption.type) {
+        case 'commonjs': {
+          codepointsContent = 'module.exports = ' + codepointsContent + ";";
+          break;
+        }
+        case 'web': {
+          codepointsContent = [
+            'if (typeof webfontIconCodepoints === \'undefined\') {',
+            '  webfontIconCodepoints = {};',
+            '}',
+            'webfontIconCodepoints[' + JSON.stringify(generatorOptions.fontName) + '] = ' + codepointsContent + ';'
+          ].join('\n');
+          break;
+        }
+        case 'json': {
+          break;
+        }
+      }
+      var codepointsFilename = emitOption.fileName;
+      var chunkHash = codepointsFilename.indexOf('[chunkhash]') !== -1
+            ? hashFiles(generatorOptions.files, options.hashLength) : '';
+      codepointsFilename = codepointsFilename
+                  .replace('[chunkhash]', chunkHash)
+                  .replace('[fontname]', generatorOptions.fontName);
+      codepointsFilename = loaderUtils.interpolateName(loaderContext,
+        codepointsFilename,
+        {
+          context: loaderContext.rootContext || loaderContext.options.context || loaderContext.context,
+          content: codepointsContent
+        }
+      );
+      loaderContext.emitFile(codepointsFilename, codepointsContent);
+    })
+  }
+};

--- a/index.js
+++ b/index.js
@@ -182,6 +182,11 @@ module.exports = function (content) {
         (Buffer.from(res[format]).toString('base64'));
       }
     }
+    var emitCodepointsOptions = fontConfig.emitCodepoints || options.emitCodepoints || null;
+    if (emitCodepointsOptions) {
+      const emitCodepoints = require('./emit-codepoints');
+      emitCodepoints.emitFiles(this, emitCodepointsOptions, generatorOptions);
+    }
 
     cb(null, res.generateCss(urls));
   });


### PR DESCRIPTION
The purpose of this change is to add a new option: emitCodepoints, as described in the changed README.md

It allows for the person using the loader to generate one of more codepoint files, containing both the user set and the auto generated codepoints. It is handy for use both on html pages or required directly in the webpacked source code, in both cases in order to be able to generate icons programatically without the need to set up the codepoints in advance.

Here is a working example, based on the example available at the "test" folder

`entry.js`
```javascript
require('./myfont.font');
require('./myfont2.font');
```

`myfont.font.js`
```javascript
module.exports = {
  'files': [
    './test-svg/*.svg'
  ],
  'fontName': 'myfonticons',
  'classPrefix': 'myfonticon-', 
  'baseSelector': '.myfonticon',
  'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
  'fixedWidth': true,
  'embed': true,
  'fileName': 'app.[fontname].[chunkhash].[ext]',
  'emitCodepoints': [ { 'fileName': '[fontname].codepoints.js', 'type': 'web' }, { 'fileName': '[fontname].codepoints.json', 'type': 'json' }, { 'fileName': '[fontname].codepoints.import.js', 'type': 'commonjs' }, { 'fileName': 'codepoints.myfonticons.return.json', 'type': 'json'  } ]
};
```

`myfont2.js`
```javascript
module.exports = {
  'files': [
    './test-svg/*.svg'
  ],
  'fontName': 'secondfonticons',
  'classPrefix': 'secondfonticon-',
  'baseSelector': '.secondfonticon',
  'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
  'fixedWidth': true,
  'embed': true,
  'fileName': 'app.[fontname].[chunkhash].[ext]',
  'emitCodepoints': [ { 'fileName': '[fontname].codepoints.js', 'type': 'web' }, { 'fileName': '[fontname].codepoints.json', 'type': 'json' }, { 'fileName': '[fontname].codepoints.import.js', 'type': 'commonjs' }, { 'fileName': 'codepoints.myfonticons.return.json', 'type': 'json'  } ]
};
```

`index.html`
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <script type="application/javascript" src="app.bundle.js"></script>
    <script type="application/javascript" src="myfonticons.codepoints.js"></script>
    <script type="application/javascript" src="secondfonticons.codepoints.js"></script>
    <script type="application/javascript">
      window.onload = function() {
      console.log((String.fromCharCode(webfontIconCodepoints['myfonticons']['alert'])).length);
        document.getElementById('hello').setAttribute('data-icon-codepoints', 
          String.fromCharCode(webfontIconCodepoints['myfonticons']['plus']) + ' ' + 
          String.fromCharCode(webfontIconCodepoints['myfonticons']['briefcase'])
        );
      }
    </script>
    <style>
      p {
        display: inline-block;
      }
      p:before {
        display: block;
        font-size: 16px;
        color: red;
        font-style: normal;
        font-weight: normal;
        font-family: "myfonticons";
        content: attr(data-icon-codepoints);
        line-height: 1;
        text-align: center;
      }
    </style>
  </head>
  <body>
    <p id="hello">Hello World</p>
  </body>
</html>
```

With the resulting page being the following:
![resulting_page](https://user-images.githubusercontent.com/11506327/43831332-ae1265f4-9afb-11e8-9cf0-53d4155d005e.png)

The code change is very limited:
* In the index.js it is checked for the existence of the `emitCodepoints` option in either the fontConfig and the loader options
* if it exists, the helper `emit-codepoints.js` module is loaded and its `emitFiles` method called

The `emit-codepoints.js` module exports two methods:
* `createArrayCodepointFiles(codepointFiles, elem)`: takes an Array as first parameter to which it appends the option received as second parameter, normalized.
* `emitFiles(loaderContext, emitCodepointsOptions, generatorOptions)`: it takes the loader context (the `this`variable in the loader), the option received either in the font configuration file or the loader option and the generator Options (after it already generated the codepoints), generates the normalized array of codepoint files (with the appropriated names and types), transverses it and emit the files as requested.

Hoping this is a valuable addition worthy of inclusion

Best regards