### PR TITLE
Bugfixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var loaderUtils = require('loader-utils');
-var webfontsGenerator = require('webfonts-generator');
+var webfontsGenerator = require('@vusion/webfonts-generator');
 var path = require('path');
 var glob = require('glob');
 var url = require('url');

--- a/index.js
+++ b/index.js
@@ -166,7 +166,14 @@ module.exports = function (content) {
 
   var cb = this.async();
 
-  var publicPath = options.publicPath || (webpackOptions.output && webpackOptions.output.publicPath) || '/';
+  const publicPath = typeof options.publicPath === 'string'
+  ? options.publicPath === '' || options.publicPath.endsWith('/')
+  ? options.publicPath
+  : `${options.publicPath}/`
+  : typeof options.publicPath === 'function'
+  ? options.publicPath(this.resourcePath, this.rootContext)
+  : this._compilation.outputOptions.publicPath;
+
   var embed = !!generatorOptions.embed;
 
   if (generatorOptions.cssTemplate) {

--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ module.exports = function (content) {
       var chunkHash = filename.indexOf('[chunkhash]') !== -1
         ? hashFiles(generatorOptions.files, options.hashLength) : '';
 
+      filename = fontConfig.dest.concat(filename);
       filename = filename
         .replace('[chunkhash]', chunkHash)
         .replace('[fontname]', generatorOptions.fontName)

--- a/index.js
+++ b/index.js
@@ -128,8 +128,8 @@ module.exports = function (content) {
     generatorOptions.cssTemplate = path.resolve(this.context, fontConfig.cssTemplate);
   }
 
-  if (fontConfig.cssFontsPath) {
-    generatorOptions.cssFontsPath = path.resolve(this.context, fontConfig.cssFontsPath);
+  if (fontConfig.cssFontsUrl) {
+    generatorOptions.cssFontsUrl = path.resolve(this.context, fontConfig.cssFontsUrl);
   }
 
   if (fontConfig.htmlTemplate) {

--- a/index.js
+++ b/index.js
@@ -180,8 +180,8 @@ module.exports = function (content) {
     this.addDependency(generatorOptions.cssTemplate);
   }
 
-  if (generatorOptions.cssFontsPath) {
-    this.addDependency(generatorOptions.cssFontsPath);
+  if (generatorOptions.cssFontsUrl) {
+    this.addDependency(generatorOptions.cssFontsUrl);
   }
 
   webfontsGenerator(generatorOptions, (err, res) => {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Jérôme Brunel",
   "license": "MIT",
   "dependencies": {
-    "glob": "^7.1.1",
+    "@vusion/webfonts-generator": "github:vusion/webfonts-generator",
+    "glob": "^7.1.4",
     "hash-files": "^1.1.1",
-    "loader-utils": "^1.0.2",
-    "webfonts-generator": "^0.4.0"
+    "loader-utils": "^1.2.3"
   },
   "devDependencies": {
     "semistandard": "^13.0.1"


### PR DESCRIPTION
- Fix #68 
- dest option has been fully ignored, now its working
- changed to @vusion/webfonts-generator because this is the last upadted version and will still be developed. Old webfonts-generator has been archived!
Why github version? -> npm shows still very old version.
- PublicPath will be now used from webpack config.