### PR TITLE
Exclude tests from NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A WebPack loader to automaticaly generate font files and CSS to make your own icon font",
   "repository": "jeerbl/webfonts-loader",
   "main": "index.js",
+  "files": [
+    "*.js"
+  ],
   "scripts": {
     "test": "semistandard && ./runTest.sh && ./runTestEmbed.sh",
     "postinstall": "github-sponsors",


### PR DESCRIPTION
This reduces the unpacked size from 74,890,691 bytes to 19,420 bytes.