### PR TITLE
Remove hash-files dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -493,7 +493,8 @@
     "async": {
       "version": "1.5.2",
       "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1751,7 +1752,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -2090,15 +2092,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-all": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
-      "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-      "requires": {
-        "glob": "^7.0.5",
-        "yargs": "~1.2.6"
-      }
-    },
     "global-dirs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
@@ -2233,18 +2226,6 @@
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
-    },
-    "hash-files": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hash-files/-/hash-files-1.1.1.tgz",
-      "integrity": "sha1-X4nGTvIezmnIJhJUt2Wb1A6R2N4=",
-      "requires": {
-        "async": "^1.5.2",
-        "glob-all": "^3.0.3",
-        "opter": "^1.1.0",
-        "read-files": "^0.1.0",
-        "underscore": "^1.8.3"
-      }
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -2632,6 +2613,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2858,7 +2840,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.invert": {
       "version": "4.3.0",
@@ -2875,7 +2858,8 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -2985,11 +2969,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-      "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
     },
     "minipass": {
       "version": "2.9.0",
@@ -3202,11 +3181,6 @@
       "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3232,19 +3206,6 @@
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
-      }
-    },
-    "opter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/opter/-/opter-1.1.0.tgz",
-      "integrity": "sha1-JZiuu2Cz8acyKvEJcIb055jISnY=",
-      "requires": {
-        "commander": "2.x.x",
-        "js-yaml": "3.x.x",
-        "object-path": "0.x.x",
-        "underscore": "1.x.x",
-        "z-schema": "^3.0.1",
-        "z-schema-errors": "0.0.1"
       }
     },
     "optionator": {
@@ -3882,11 +3843,6 @@
           "dev": true
         }
       }
-    },
-    "read-files": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/read-files/-/read-files-0.1.0.tgz",
-      "integrity": "sha1-YGu3oBd5Utai+YPVmAlglDFNMh4="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -6065,11 +6021,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validator": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.7.0.tgz",
-      "integrity": "sha512-7Z4kif6HeMLroCQZvh8lwCtmPOqBTkTkt5ibXtJR8sOkzWdjW+YIJOZUpPFlfq59zYvnpSPVd4UX5QYnSCLWgA=="
-    },
     "varstream": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz",
@@ -6308,7 +6259,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
@@ -6327,33 +6279,6 @@
       "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
       "requires": {
         "@babel/runtime": "^7.8.7"
-      }
-    },
-    "yargs": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
-      "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-      "requires": {
-        "minimist": "^0.1.0"
-      }
-    },
-    "z-schema": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.23.0.tgz",
-      "integrity": "sha512-D8XV0BiHuQbWNEgu68RpjFZJ0C7jt+WYoszXKOohe54TdoTTauUvBQx+lsYCdalGIjGTFdQs5dxKvCUonUERzQ==",
-      "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
-      }
-    },
-    "z-schema-errors": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/z-schema-errors/-/z-schema-errors-0.0.1.tgz",
-      "integrity": "sha1-4GJwpMpDklcp8ldkeJyp9Gv/D30=",
-      "requires": {
-        "xtend": "^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@vusion/webfonts-generator": "^0.6.1",
     "github-sponsors": "^1.0.1",
     "glob": "^7.1.6",
-    "hash-files": "^1.1.1",
     "loader-utils": "^1.4.0"
   },
   "devDependencies": {

--- a/utils.js
+++ b/utils.js
@@ -1,8 +1,19 @@
-var hashFiles = require('hash-files');
+var crypto = require('crypto');
+var fs = require('fs');
 
 module.exports = {
   hashFiles: function (files, hashLength) {
+    // FIXME: For compatibility with the hash-files package, this
+    // function just sorts by filename and hashes the concatenation of
+    // the file contents. This algorithm will not detect certain
+    // changes where files are renamed or chunks are moved across
+    // file boundaries (https://github.com/mac-/hash-files/issues/4).
+
     hashLength = hashLength && +hashLength >= 8 && +hashLength <= 32 ? +hashLength : 20;
-    return hashFiles.sync({ files: files }).slice(0, hashLength);
+    var hash = crypto.createHash('sha1');
+    Array.from(new Set(files)).sort().forEach(function (file) {
+      hash.update(fs.readFileSync(file));
+    });
+    return hash.digest('hex').slice(0, hashLength);
   }
 };


### PR DESCRIPTION
hash-files is a seemingly unmaintained package with a large dependency tree, a command line interface, and many features and options that we don’t use. Replace the one function we do use with five lines of equivalent code.

Note that because I’ve reimplemented the same algorithm for compatibility, I haven’t fixed https://github.com/mac-/hash-files/issues/4 “Concatenating files can generate same hash”.