### PR TITLE
Remove writeFiles option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,6 @@ See [webfonts-generator#html](https://github.com/vusion/webfonts-generator#html)
 
 See [webfonts-generator#htmldest](https://github.com/vusion/webfonts-generator#htmldest)
 
-##### `writeFiles`, Boolean
-
-See [webfonts-generator#writefiles](https://github.com/vusion/webfonts-generator#writefiles)
-
 ##### `ligature`, Boolean
 
 See [webfonts-generator#ligature](https://github.com/vusion/webfonts-generator#ligature)

--- a/index.js
+++ b/index.js
@@ -104,11 +104,11 @@ module.exports = function (content) {
     cssDest: fontConfig.cssDest ? path.resolve(this.context, fontConfig.cssDest, fontConfig.fontName.toLowerCase() + '.css') : undefined,
     cssFontsUrl: fontConfig.cssFontsUrl || '',
     embed: fontConfig.embed || false,
-    formatOptions: fontConfig.formatOptions || {}
+    formatOptions: fontConfig.formatOptions || {},
+    writeFiles: false
   };
 
   if ('ligature' in fontConfig) generatorOptions.ligature = fontConfig.ligature;
-  if ('writeFiles' in fontConfig) generatorOptions.writeFiles = fontConfig.writeFiles;
   if ('htmlTemplate' in fontConfig) generatorOptions.htmlTemplate = fontConfig.htmlTemplate;
 
   // This originally was in the object notation itself.


### PR DESCRIPTION
`writeFiles: true` doesn’t make sense for a Webpack loader.

Fixes #119.