### PR TITLE
Enable write files option

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = function (content) {
     cssFontsUrl: fontConfig.cssFontsUrl || '',
     embed: fontConfig.embed || false,
     formatOptions: fontConfig.formatOptions || {},
-    writeFiles: false
+    writeFiles: fontConfig.writeFiles || false
   };
 
   if ('ligature' in fontConfig) generatorOptions.ligature = fontConfig.ligature;
@@ -227,7 +227,9 @@ module.exports = function (content) {
           }
         );
         urls[format] = url.resolve(publicPath, formatFilename.replace(/\\/g, '/'));
-        this.emitFile(formatFilename, res[format]);
+        if (!generatorOptions.writeFiles) {
+          this.emitFile(formatFilename, res[format]);
+        }
       } else {
         urls[format] = 'data:' +
         mimeTypes[format] +


### PR DESCRIPTION
Hi @jeerbl and @andersk 

Sorry for my inactivity lately regarding to #123. I still would love to enable the `writeFiles` option from the webfonts generator. This is a very powerful feature to generate a separate SCSS file which will allow the users to work with variables and mixins inside the webpack stack. I had time to optimize my pull request: The `writeFiles` option defaults to `false` now and the `emitFile` function will be skipped if the `writeFiles` option is `true`. As you mentioned I could use the webfonts generator directly but then I would lose the comfort of the webpack watch task and your handy `getFilesAndDeps` function. I'm currently using it only for one webfont so my setup looks as followed:

icon.js:
```
module.exports = {
  files: [
    '../../../icons/*.svg'
  ]
}
```

webpack rules:
```
{
  test: /icon.js/,
  use: [
    {
      loader: 'css-loader',
    },
    {
      loader: 'webfonts-loader',
      options: {
        scssFile: true,
        writeFiles: true,
        fontName: 'Icons',
        types: ['woff2', 'ttf'],
        dest: paths.assets + '/fonts/',
        cssDest: paths.assets + '/styles/1_settings/icons/',
        cssTemplate: paths.webpack + '/templates/icons.hbs'
      }
    }
  ]
},
{
  test: /\.(sa|sc|c)ss$/i,
  use: [
    MiniCssExtractPlugin.loader,
    {
      loader: 'css-loader'
    },
    {
      loader: 'postcss-loader',
      options: {
        postcssOptions: {
          plugins: [
            ['postcss-preset-env']
          ]
        }
      }
    },
    {
      loader: 'sass-loader'
    }
  ]
}
```

in the cssTemplate I'm generating a map with all the icons:
```
$icons: (
  {{#each codepoints}}
    '{{@key}}': '\\{{this}}',
  {{/each}}
);
```

now I can use all the icons in my main SCSS like this:
```
@import "1_settings/icons/icons";

// Mixins

@mixin icon($name) {
  content: map-get($icons, $name);
  font-family: Icons;
  font-style: normal;
  font-weight: normal;
}

@mixin icon-wrapper($name) {
  line-height: 1;
  &::before {
    @include icon($name);
  }
}

// Example 1

.o-icon--example {
  @include icon-wrapper(example);
}

// Example 2

.c-example {
  &::after {
    @include icon(example);
  }
}
```

Thanks in advance and cheers,
Michael