### PR TITLE
Generate html file

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,6 +241,20 @@ module.exports = function (content) {
       emitCodepoints.emitFiles(this, emitCodepointsOptions, generatorOptions, options);
     }
 
+    if (generatorOptions.html) {
+      var htmlDest = generatorOptions.htmlDest ? generatorOptions.htmlDest : generatorOptions.fontName + '.html'
+      htmlDest = generatorOptions.dest.concat(htmlDest);
+      var htmlContent = res.generateHtml(urls)
+      var htmlFilename = loaderUtils.interpolateName(this,
+        htmlDest,
+        {
+          context: this.rootContext || this.options.context || this.context,
+          content: htmlContent
+        }
+      );
+      this.emitFile(htmlFilename, htmlContent);
+    }
+
     cb(null, res.generateCss(urls));
   });
 };

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ module.exports = function (content) {
     }
 
     if (generatorOptions.html) {
-      var htmlDest = generatorOptions.htmlDest ? generatorOptions.htmlDest : generatorOptions.fontName + '.html'
+      var htmlDest = generatorOptions.htmlDest ? generatorOptions.htmlDest : generatorOptions.fontName + '.html';
       htmlDest = generatorOptions.dest.concat(htmlDest);
       htmlDest = loaderUtils.interpolateName(this,
         htmlDest,
@@ -256,7 +256,7 @@ module.exports = function (content) {
         relativeUrls[key] = path.relative(url.resolve(publicPath, path.dirname(htmlDest.replace(/\\/g, '/'))), urls[key]);
       }
 
-      var htmlContent = res.generateHtml(relativeUrls)
+      var htmlContent = res.generateHtml(relativeUrls);
       this.emitFile(htmlDest, htmlContent);
     }
 

--- a/index.js
+++ b/index.js
@@ -244,15 +244,20 @@ module.exports = function (content) {
     if (generatorOptions.html) {
       var htmlDest = generatorOptions.htmlDest ? generatorOptions.htmlDest : generatorOptions.fontName + '.html'
       htmlDest = generatorOptions.dest.concat(htmlDest);
-      var htmlContent = res.generateHtml(urls)
-      var htmlFilename = loaderUtils.interpolateName(this,
+      htmlDest = loaderUtils.interpolateName(this,
         htmlDest,
         {
-          context: this.rootContext || this.options.context || this.context,
-          content: htmlContent
+          context: this.rootContext || this.options.context || this.context
         }
       );
-      this.emitFile(htmlFilename, htmlContent);
+
+      var relativeUrls = {};
+      for (var key in urls) {
+        relativeUrls[key] = path.relative(url.resolve(publicPath, path.dirname(htmlDest.replace(/\\/g, '/'))), urls[key]);
+      }
+
+      var htmlContent = res.generateHtml(relativeUrls)
+      this.emitFile(htmlDest, htmlContent);
     }
 
     cb(null, res.generateCss(urls));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@vusion/webfonts-generator": "^0.7.1",
+    "@vusion/webfonts-generator": "^0.7.2",
     "glob": "^7.1.6",
     "loader-utils": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webfonts-loader",
   "version": "7.2.0",
-  "description": "A WebPack loader to automaticaly generate font files and CSS to make your own icon font",
+  "description": "A WebPack loader to automatically generate font files and CSS to make your own icon font",
   "repository": "jeerbl/webfonts-loader",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@vusion/webfonts-generator": "^0.7.0",
+    "@vusion/webfonts-generator": "^0.7.1",
     "glob": "^7.1.6",
     "loader-utils": "^2.0.0"
   },


### PR DESCRIPTION
Since `writeFiles` is false by default the `html` option is useless. To keep that feature we need to generate the html file as well.

This PR should fix #138