### PR TITLE
Fixing bug where no CSS/SCSS file is written & more flexibility for cssFile names

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = function (content) {
     cssFontsUrl: fontConfig.cssFontsUrl || '',
     embed: fontConfig.embed || false,
     formatOptions: fontConfig.formatOptions || {},
-    writeFiles: false
+    writeFiles: rawFontConfig.writeFiles ?? true
   };
 
   if ('startCodepoint' in fontConfig) generatorOptions.startCodepoint = fontConfig.startCodepoint;

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function (content) {
     dest: fontConfig.dest || '',
     html: fontConfig.html || false,
     htmlDest: fontConfig.htmlDest || undefined,
-    cssDest: fontConfig.cssDest ? path.resolve(this.context, fontConfig.cssDest, fontConfig.fontName.toLowerCase() + '.css') : undefined,
+    cssDest: fontConfig.cssDest ? path.resolve(this.context, fontConfig.cssDest, fontConfig.cssFileName ?? (fontConfig.fontName.toLowerCase() + '.css')) : undefined,
     cssFontsUrl: fontConfig.cssFontsUrl || '',
     embed: fontConfig.embed || false,
     formatOptions: fontConfig.formatOptions || {},
@@ -165,7 +165,7 @@ module.exports = function (content) {
 
   // Spit out SCSS file to same path as CSS file to easily use mixins (scssFile must be true)
   if (fontConfig.cssDest && fontConfig.scssFile) {
-    generatorOptions.cssDest = path.resolve(this.context, fontConfig.cssDest, fontConfig.fontName.toLowerCase() + '.scss');
+    generatorOptions.cssDest = path.resolve(this.context, fontConfig.cssDest, fontConfig.cssFileName ?? (fontConfig.fontName.toLowerCase() + '.scss'));
   }
 
   // svgicons2svgfont stuff


### PR DESCRIPTION
I found your NPM package to gerenate fonts from SVG; I already worked with Grunt & fontforge, but I really like your package.

Two things are a bit annoying:

- I like to generate a SCSS file into my other scss resource folder. In the original settings, this is not possible. With the ability of setting the writeFiles in font config file, I can remove the MiniCssExtractPlugin from webpack, set the cssDest option and get my SCSS file there
- With the new cssFileName its possbile to have more control over the generated file name. I prefere to use [sassfolder]/fonts/_icons.scss as example. This was not possible because of fully generated path.

Thanks for your grate work!
Marc